### PR TITLE
Potential fix for code scanning alert no. 1: Incomplete string escaping or encoding

### DIFF
--- a/views/events/index.ejs
+++ b/views/events/index.ejs
@@ -179,7 +179,7 @@
               <form action="/events/<%= event.id %>/unregister" method="POST" style="display:inline;">
                 <input type="hidden" name="_csrf" value="<%= csrfToken() %>" />
                 <button type="submit" class="btn btn--ghost btn--xs"
-                        onclick="return confirm('Annuler votre inscription à « <%= event.nom.replace(/'/g, '\\\'') %> » ?')">
+                        onclick="return confirm('Annuler votre inscription à « ' + <%- JSON.stringify(event.nom) %> + ' » ?')">
                   <i class="fas fa-user-minus"></i> Se désinscrire
                 </button>
               </form>


### PR DESCRIPTION
Potential fix for [https://github.com/duckplatform/LANPartyManager/security/code-scanning/1](https://github.com/duckplatform/LANPartyManager/security/code-scanning/1)

Use a context-appropriate, complete escaping approach for embedding dynamic text into JavaScript string literals in inline handlers.  
The best minimal fix here is to avoid custom single-character escaping and serialize the string as JSON, which correctly escapes quotes, backslashes, and control characters for JS string usage.

In `views/events/index.ejs`, replace the current `replace(/'/g, '\\\'')` usage on line 182 with `JSON.stringify(event.nom)`, and build the confirm message by concatenating JS string literals with that serialized value:

- Keep existing functionality (same confirmation prompt text and behavior).
- Remove brittle manual escaping logic.
- No new imports or dependencies required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
