### PR TITLE
Potential fix for code scanning alert no. 2: Missing CSRF middleware

### DIFF
--- a/app.js
+++ b/app.js
@@ -118,6 +118,9 @@ const {
   getTokenFromRequest: (req) => req.body._csrf || req.headers['x-csrf-token'],
 });
 
+// Applique la vérification CSRF sur les routes protégées par session/cookie.
+app.use(csrfSynchronisedProtection);
+
 // Rend csrfToken() disponible dans les routes via req.csrfToken()
 app.use((req, res, next) => {
   req.csrfToken = () => generateCsrfToken(req);


### PR DESCRIPTION
Potential fix for [https://github.com/duckplatform/LANPartyManager/security/code-scanning/2](https://github.com/duckplatform/LANPartyManager/security/code-scanning/2)

Apply the already-configured `csrfSynchronisedProtection` middleware globally (or at least to all state-changing routes) **after** body parsing and session setup, and keep token generation available to views/forms.  
Best minimal fix without changing existing functionality: in `app.js`, add `app.use(csrfSynchronisedProtection);` after `app.use(flash());` and after the `csrfSync(...)` config block. This ensures POST/PUT/PATCH/DELETE requests are validated using the token retrieved from `req.body._csrf` or `x-csrf-token`, addressing all alert variants at once for handlers behind this middleware chain.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
