### PR TITLE
Potential fix for code scanning alert no. 4: Type confusion through parameter tampering

### DIFF
--- a/services/discordCommands.js
+++ b/services/discordCommands.js
@@ -109,6 +109,11 @@ function verifySignature(rawBody, signature, timestamp, publicKeyHex) {
     return false;
   }
 
+  if (!Buffer.isBuffer(rawBody) || typeof signature !== 'string' || typeof timestamp !== 'string' || typeof publicKeyHex !== 'string') {
+    logger.warn('[DISCORD_INTERACTIONS] Signature verification failed: invalid parameter types');
+    return false;
+  }
+
   try {
     logger.debug(`[DISCORD_INTERACTIONS] Verifying signature - timestamp: ${timestamp}, bodySize: ${rawBody.length} bytes, pubKeyLen: ${publicKeyHex.length} chars`);
     


### PR DESCRIPTION
Potential fix for [https://github.com/duckplatform/LANPartyManager/security/code-scanning/4](https://github.com/duckplatform/LANPartyManager/security/code-scanning/4)

La correction la plus robuste est d’ajouter une validation stricte des types **avant** toute utilisation de `rawBody` (et idéalement aussi des headers attendus en string) puis de rejeter (`false`) si les types sont invalides.

Meilleure approche sans changer la fonctionnalité :
- **Dans `services/discordCommands.js`**, dans `verifySignature(...)`, renforcer la garde d’entrée :
  - vérifier `Buffer.isBuffer(rawBody)`,
  - vérifier `typeof signature === 'string'`,
  - vérifier `typeof timestamp === 'string'`,
  - vérifier `typeof publicKeyHex === 'string'`.
- Conserver la logique actuelle de vérification Ed25519 et le contrat de retour (`boolean`), mais retourner `false` immédiatement en cas de type invalide.
- Cela neutralise la confusion de type signalée par CodeQL au sink (`rawBody.length`, `rawBody.toString`), sans modifier le comportement métier attendu.

Aucun changement n’est nécessaire dans `routes/discord.js` pour corriger ce finding précis, car le durcissement au niveau service couvre le point vulnérable.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
