### PR TITLE
Potential fix for code scanning alert no. 2: Missing CSRF middleware

### DIFF
--- a/app.js
+++ b/app.js
@@ -118,6 +118,12 @@ const {
   getTokenFromRequest: (req) => req.body._csrf || req.headers['x-csrf-token'],
 });
 
+app.use(csrfSynchronisedProtection);
+app.use((req, res, next) => {
+  res.locals.csrfToken = generateCsrfToken(req);
+  next();
+});
+
 // Applique la vérification CSRF sur les routes protégées par session/cookie.
 app.use(csrfSynchronisedProtection);
 


### PR DESCRIPTION
Potential fix for [https://github.com/duckplatform/LANPartyManager/security/code-scanning/2](https://github.com/duckplatform/LANPartyManager/security/code-scanning/2)

To fix this, ensure CSRF protection middleware is actually enforced in the Express pipeline for unsafe methods, after body parsing and session setup (so token extraction and session-backed token state both work), and before application routes that mutate state.

Best single fix in `app.js`:
1. Keep existing `csrfSync({...})` configuration.
2. Mount `csrfSynchronisedProtection` as middleware right after its definition.
3. (Recommended in same location) expose a per-request token for views/forms via `res.locals.csrfToken = generateCsrfToken(req)` so existing EJS forms can include `_csrf` without changing route logic.

This addresses all variants at once by making CSRF protection part of the common middleware chain for handlers served with session cookies.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
