### PR TITLE
Potential fix for code scanning alert no. 2: Missing CSRF middleware

### DIFF
--- a/app.js
+++ b/app.js
@@ -118,6 +118,15 @@ const {
   getTokenFromRequest: (req) => req.body._csrf || req.headers['x-csrf-token'],
 });
 
+// Active la vérification CSRF pour les requêtes mutantes
+app.use(csrfSynchronisedProtection);
+
+// Rend le token disponible dans les vues/formulaires (champ caché _csrf)
+app.use((req, res, next) => {
+  res.locals.csrfToken = generateCsrfToken(req);
+  next();
+});
+
 app.use(csrfSynchronisedProtection);
 app.use((req, res, next) => {
   res.locals.csrfToken = generateCsrfToken(req);


### PR DESCRIPTION
Potential fix for [https://github.com/duckplatform/LANPartyManager/security/code-scanning/2](https://github.com/duckplatform/LANPartyManager/security/code-scanning/2)

To fix this without changing existing functionality, mount `csrfSynchronisedProtection` as middleware after body parsing/session setup (so token extraction and session access work) and before application routes that handle state-changing requests. Also add a small middleware to expose `generateCsrfToken(req)` to templates/locals so forms can include `_csrf`, which is required for valid POST/PUT/PATCH/DELETE requests.

In `app.js`, update the CSRF section where `csrfSync({...})` is defined:
1. Keep the existing `csrfSync` configuration.
2. Add `app.use(csrfSynchronisedProtection);` after `flash()` (and after parsers/session), before route mounting for protected endpoints.
3. Add `app.use((req, res, next) => { res.locals.csrfToken = generateCsrfToken(req); next(); });` so server-rendered forms can embed tokens.

This single middleware placement addresses all alert variants tied to cookie-backed handlers in this file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
