### PR TITLE
Potential fix for code scanning alert no. 2: Missing CSRF middleware

### DIFF
--- a/app.js
+++ b/app.js
@@ -118,6 +118,15 @@ const {
   getTokenFromRequest: (req) => req.body._csrf || req.headers['x-csrf-token'],
 });
 
+// Applique la vérification CSRF à toutes les routes suivantes
+app.use(csrfSynchronisedProtection);
+
+// Rend le token disponible dans les vues/formulaires (_csrf)
+app.use((req, res, next) => {
+  res.locals.csrfToken = generateCsrfToken(req, res);
+  next();
+});
+
 // Active la vérification CSRF pour les requêtes mutantes
 app.use(csrfSynchronisedProtection);
 


### PR DESCRIPTION
Potential fix for [https://github.com/duckplatform/LANPartyManager/security/code-scanning/2](https://github.com/duckplatform/LANPartyManager/security/code-scanning/2)

Add the CSRF protection middleware to the Express middleware chain **after** body parsing/session setup and **before** protected routes are handled.  
Best fix in this file: immediately after the `csrfSync(...)` setup, mount:

- `app.use(csrfSynchronisedProtection);` to enforce token checks on unsafe methods.
- optionally expose a token to views with `res.locals.csrfToken = generateCsrfToken(req, res);` so forms can include `_csrf` without changing route logic.

In `app.js`, this should be inserted in the CSRF section (around lines 111–119 shown), keeping existing behavior while ensuring all downstream handlers are protected. No import change is needed because `csrfSync` is already imported.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
