### PR TITLE
Potential fix for code scanning alert no. 4: Type confusion through parameter tampering

### DIFF
--- a/routes/discord.js
+++ b/routes/discord.js
@@ -61,9 +61,11 @@ router.post(
     const timestampHeader = req.headers['x-signature-timestamp'];
     const signature = Array.isArray(signatureHeader) ? signatureHeader[0] : signatureHeader;
     const timestamp = Array.isArray(timestampHeader) ? timestampHeader[0] : timestampHeader;
-    const rawBody   = req.body; // Buffer grâce à express.raw()
+    const rawBody = Buffer.isBuffer(req.body)
+      ? req.body
+      : (typeof req.body === 'string' ? Buffer.from(req.body, 'utf-8') : null);
 
-    if (typeof signature !== 'string' || typeof timestamp !== 'string' || !Buffer.isBuffer(rawBody)) {
+    if (typeof signature !== 'string' || typeof timestamp !== 'string' || !rawBody) {
       logger.warn(`[DISCORD_INTERACTIONS] Invalid request parameter types (ip=${req.ip})`);
       return res.status(401).json({ error: 'Invalid request signature' });
     }


### PR DESCRIPTION
Potential fix for [https://github.com/duckplatform/LANPartyManager/security/code-scanning/4](https://github.com/duckplatform/LANPartyManager/security/code-scanning/4)

General fix: normalize and validate untrusted request data at the HTTP boundary before passing it deeper, and ensure only a canonical `Buffer` reaches signature verification.

Best concrete fix (without changing functionality): in `routes/discord.js`, replace direct assignment of `req.body` with strict normalization:
- if `req.body` is already a `Buffer`, keep it;
- if it is a `string`, convert with `Buffer.from(..., 'utf-8')`;
- otherwise (including arrays/objects), set to `null` and reject with existing 401 path.

This keeps expected behavior for valid Discord requests (Buffer), safely supports equivalent string payloads, and blocks array-based type confusion. No changes are required in `services/discordCommands.js` because it already defensively checks types.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
