### PR TITLE
Bump helmet from 8.1.0 to 8.3.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "express-rate-limit": "^8.5.1",
         "express-session": "^1.17.3",
         "express-validator": "^7.0.1",
-        "helmet": "^8.1.0",
+        "helmet": "^8.3.0",
         "marked": "^18.0.2",
         "method-override": "^3.0.0",
         "morgan": "^1.11.0",
@@ -2253,12 +2253,15 @@
       }
     },
     "node_modules/helmet": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/helmet/-/helmet-8.1.0.tgz",
-      "integrity": "sha512-jOiHyAZsmnr8LqoPGmCjYAaiuWwjAPLgY8ZX2XrmHawt99/u1y6RgrZMTeoPfpUbV96HOalYgz1qzkRbw54Pmg==",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/helmet/-/helmet-8.3.0.tgz",
+      "integrity": "sha512-Qgpiaws3Sm30Av8Eah6sjMCZZwjlBu+E68rhpCWBshY1lb09HtLwj5GviX0OyQIn+ulUS0iX0AxN5n3tLZzz1w==",
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/EvanHahn"
       }
     },
     "node_modules/htmlparser2": {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "express-rate-limit": "^8.5.1",
     "express-session": "^1.17.3",
     "express-validator": "^7.0.1",
-    "helmet": "^8.1.0",
+    "helmet": "^8.3.0",
     "marked": "^18.0.2",
     "method-override": "^3.0.0",
     "morgan": "^1.11.0",


### PR DESCRIPTION
Remplace la PR dependabot #78 fermée (conflit de lockfile). Rebasée sur main à jour.

Testé localement avec Node.js 24 :
- `npm run lint` : OK
- `npm test` : 278 passing

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>