### PR TITLE
Bump ejs from 5.0.2 to 6.0.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "connect-flash": "^0.1.1",
         "csrf-sync": "^4.2.1",
         "discord.js": "^14.26.3",
-        "ejs": "^5.0.2",
+        "ejs": "^6.0.1",
         "express": "^5.2.1",
         "express-rate-limit": "^8.5.1",
         "express-session": "^1.17.3",
@@ -1341,9 +1341,9 @@
       "license": "MIT"
     },
     "node_modules/ejs": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/ejs/-/ejs-5.0.2.tgz",
-      "integrity": "sha512-IpbUaI/CAW86l3f+T8zN0iggSc0LmMZLcIW5eRVStLVNCoTXkE0YlncbbH50fp8Cl6zHIky0sW2uUbhBqGw0Jw==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/ejs/-/ejs-6.0.1.tgz",
+      "integrity": "sha512-UaaM14yby8U3k02ihS1Bmj5Kz2d7CCQM1scxpgs4Mhkq8F1wR2gl3+Ts4h5Ne4Mnt7M9m4Dw7jsuMr3+xO4vZA==",
       "license": "Apache-2.0",
       "bin": {
         "ejs": "bin/cli.js"

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "connect-flash": "^0.1.1",
     "csrf-sync": "^4.2.1",
     "discord.js": "^14.26.3",
-    "ejs": "^5.0.2",
+    "ejs": "^6.0.1",
     "express": "^5.2.1",
     "express-rate-limit": "^8.5.1",
     "express-session": "^1.17.3",


### PR DESCRIPTION
Remplace la PR dependabot #79 fermée (conflit de lockfile). Rebasée sur main à jour.

Bump majeur mais à faible risque : le diff amont entre 5.0.2 et 6.0.1 ne touche que les shims ESM, le packaging et les tests (durcissement anti-prototype-pollution) — `lib/ejs.js` (moteur de rendu principal) est inchangé.

Testé localement avec Node.js 24 :
- `npm run lint` : OK
- `npm test` : 278 passing
- Smoke-test manuel : rendu direct de views/badge.ejs et vérification du mécanisme `include()` (partials/head, partials/foot) — OK

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>