### PR TITLE
Bump ip-address from 10.2.0 to 10.5.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2356,9 +2356,9 @@
       "license": "ISC"
     },
     "node_modules/ip-address": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
-      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.5.0.tgz",
+      "integrity": "sha512-R5SnVLJmgYYvf2F2ZgwSBnelz5G4q5AxIC277GDfUaNbrZKNANcBC7RHqYYePlszf4kBolVkJauG0ZjHHFh55g==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"


### PR DESCRIPTION
Remplace la PR dependabot #83 fermée. Transitive de express-rate-limit ; `npm update` a résolu vers la dernière version compatible (10.5.0, dependabot ciblait 10.4.0).

Testé localement avec Node.js 24 :
- `npm run lint` : OK
- `npm test` : 278 passing

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>