### PR TITLE
Bump socket.io-parser from 4.2.6 to 4.2.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4013,9 +4013,9 @@
       "license": "MIT"
     },
     "node_modules/socket.io-parser": {
-      "version": "4.2.6",
-      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.6.tgz",
-      "integrity": "sha512-asJqbVBDsBCJx0pTqw3WfesSY0iRX+2xzWEWzrpcH7L6fLzrhyF8WPI8UaeM4YCuDfpwA/cgsdugMsmtz8EJeg==",
+      "version": "4.2.7",
+      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.7.tgz",
+      "integrity": "sha512-IH/iSeO9T6gz1KkFleGDWkG9N3dl4jXVYUtMhIqH10Md0ttMer8nUNWiP1DKuNrybD2xBrixLJdCC9J6ECoYkg==",
       "license": "MIT",
       "dependencies": {
         "@socket.io/component-emitter": "~3.1.0",


### PR DESCRIPTION
Remplace la PR dependabot #84 fermée. Transitive de socket.io.

Testé localement avec Node.js 24 :
- `npm run lint` : OK
- `npm test` : 278 passing

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>